### PR TITLE
Adapted `panic.rs` to the newly stabilized message api

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![feature(start)]
 #![feature(const_fn_floating_point_arithmetic)]
-#![feature(panic_info_message)]
 
 use alloc::fmt;
 use alloc::vec::Vec;

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -31,14 +31,9 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
             None => ("(unknown file)", 0),
         };
 
-        if let Some(m) = info.message() {
-            let _ = write!(ConsoleWriter, "PANIC: {m}\n at {file}:{line}");
-        } else if let Some(m) = info.payload().downcast_ref::<&str>() {
-            let _ = write!(ConsoleWriter, "PANIC: {m}\n at {file}:{line}");
-        } else {
-            let _ = write!(ConsoleWriter, "PANIC: (no message)\n at {file}:{line}");
-        }
+        let message = info.message();
+        
+        let _ = write!(ConsoleWriter, "PANIC: {message}\n at {file}:{line}");
     }
-
     loop {}
 }


### PR DESCRIPTION

This pull request removes unneccessary/depricated code paths as well as changes the panic handler to use the newly stabilized ``PanicInfo::message``. It also removes the now unneccesary ``panic_info_message`` feature from the `lib.rs`.

see https://github.com/rust-lang/rust/issues/66745 and https://github.com/rust-lang/rust/pull/126732